### PR TITLE
Lower log level for 2 log messages + fix typos

### DIFF
--- a/modules/drain/drain.c
+++ b/modules/drain/drain.c
@@ -5,7 +5,7 @@
 static bool is_draining = false;
 
 /*
- * Iff is_draining == true, prevents new allocations and denies allocation
+ * If is_draining == true, prevents new allocations and denies allocation
  * refresh by replying with a '508 Insufficient Capacity' message.
  */
 static bool request_handler(struct restund_msgctx *ctx, int proto, void *sock,

--- a/modules/turn/alloc.c
+++ b/modules/turn/alloc.c
@@ -420,7 +420,7 @@ void allocate_request(struct turnd *turnd, struct allocation *alx,
 		sa_set_port(&public_addr, sa_port(&alx->rel_addr));
 		public = true;
 
-		restund_info("turn: mapping to public:  %J  -->  %J\n",
+		restund_debug("turn: mapping to public:  %J  -->  %J\n",
 			     &alx->rel_addr, &public_addr);
 	}
 

--- a/modules/zrest/zrest.c
+++ b/modules/zrest/zrest.c
@@ -193,7 +193,7 @@ static int module_init(void)
 	err = conf_get_str(restund_conf(), "zrest_secret", zrest.secret,
 			   sizeof(zrest.secret));
 	if (err) {
-		restund_error("zrest: missing config 'rest_secret'\n");
+		restund_error("zrest: missing config 'zrest_secret'\n");
 		return err;
 	}
 

--- a/modules/zrest/zrest.c
+++ b/modules/zrest/zrest.c
@@ -108,7 +108,7 @@ static int auth_handler(const char *user, uint8_t *ha1)
 	else if (0 == re_regex(user, strlen(user),
 			       "[0-9]+.s.[0-9]*", &expires, NULL)) {
 
-		restund_info("zrest: auth version 0\n");
+		restund_debug("zrest: auth version 0\n");
 	}
 	else {
 		restund_info("zrest: could not parse username (%s)\n", user);


### PR DESCRIPTION
Both `restund_info` log messages are outputted way too often in production. This can even increase CPU usage. Lowering the log messages to `restund_debug` fixes this.

I've also included 2 typo fixes.